### PR TITLE
Allow updating playlists via a stateUpdate event

### DIFF
--- a/data/default/playlist.json
+++ b/data/default/playlist.json
@@ -1,19 +1,42 @@
 [
     {
         "id": 1,
-        "displayName": "Color Cube",
+        "displayName": "Cubotron",
         "items": [
             {
+                "id": "966b07e9-1b52-4367-86f1-76251cc792e0",
+                "sceneId": 4,
+                "duration": 1
+            },
+            {
+                "id": "c7de37d0-646b-4c49-bad0-8247b96d1b13",
                 "sceneId": 1,
-                "duration": 10
+                "duration": 1
             },
             {
+                "id": "5651bd75-e33b-47bd-a25a-a13b41c4273a",
+                "sceneId": 4,
+                "duration": 1
+            },
+            {
+                "id": "4c6f90ca-674e-4b6e-a05d-b0f87267dbfe",
                 "sceneId": 2,
-                "duration": 10
+                "duration": 4
             },
             {
+                "id": "e5df7624-3876-4f55-b232-63a491a73524",
                 "sceneId": 3,
-                "duration": 10
+                "duration": 3
+            },
+            {
+                "id": "e81919af-7710-4a4d-b8bc-717d9d17280a",
+                "sceneId": 4,
+                "duration": 5
+            },
+            {
+                "id": "91b24ab4-3072-45ce-8545-4465917b9677",
+                "sceneId": 1,
+                "duration": 1
             }
         ]
     },
@@ -22,26 +45,32 @@
         "displayName": "Color Cube 2",
         "items": [
             {
+                "id": "72f2d59a-dc96-41ab-9a23-07c7e878d951",
                 "sceneId": 1,
                 "duration": 2
             },
             {
+                "id": "8a250c28-0a42-4c08-827d-b54d627b0bea",
                 "sceneId": 2,
                 "duration": 3
             },
             {
+                "id": "99b1352e-e544-4ed5-a1fe-f26a1a6a82ab",
                 "sceneId": 1,
                 "duration": 4
             },
             {
+                "id": "a9c698ec-5c16-411e-8558-533795bc2688",
                 "sceneId": 3,
                 "duration": 5
             },
             {
+                "id": "7432b40c-18ee-481f-b574-70f7087e5917",
                 "sceneId": 1,
                 "duration": 6
             },
             {
+                "id": "cfdc3702-70ac-498f-a7b8-b64c67d21825",
                 "sceneId": 2,
                 "duration": 7
             }

--- a/src/app/TesseractMain.java
+++ b/src/app/TesseractMain.java
@@ -51,6 +51,7 @@ public class TesseractMain extends PApplet {
   public SceneStore sceneStore;
   public PlaylistStore playlistStore;
 
+  public Playlist currentPlaylist;
 
   //Click the arrow on the line below to run the program in .idea
   public static void main(String[] args) {
@@ -106,15 +107,16 @@ public class TesseractMain extends PApplet {
     this.createBuiltInScenes();
     this.createBuiltInPlaylists();
 
-    // Save the created scenes to disk, this will eventually happen whenever state changes in the store(s)
+    // Save the created data to disk so we persist our manually created scenes/playlists
     this.sceneStore.saveDataToDisk();
+    this.playlistStore.saveDataToDisk();
 
     // Play the first playlist
     List<Playlist> playlists = this.playlistStore.getItems();
-    Playlist currentPlaylist = playlists.get(0);
-    currentPlaylist.setChannel(channel1);
+    this.currentPlaylist = playlists.get(0);
+    this.currentPlaylist.setChannel(channel1);
     // false will make the playlist play the first item w/o ever continuing to the next item
-    currentPlaylist.play(false);
+    this.currentPlaylist.play(false);
 
     // The shutdown hook will let us clean up when the application is killed
     createShutdownHook();
@@ -123,7 +125,6 @@ public class TesseractMain extends PApplet {
   @Override
   public void draw() {
     clear();
-
 
     //call run() on the current clips inside channels
     channel1.run();
@@ -198,12 +199,13 @@ public class TesseractMain extends PApplet {
 
   private void createBuiltInPlaylists() {
     List<PlaylistItem> playlistItems1 = Arrays.asList(
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 4), 10),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 1), 10),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 4), 10),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 2), 10),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 3), 10),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 4), 10)
+        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 4), 4),
+        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 1), 3),
+        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 4), 1),
+        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 2), 4),
+        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 3), 3),
+        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 4), 5),
+        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 1), 1)
     );
 
     Playlist playlist1 = new Playlist(1, "Cubotron", 60, playlistItems1);

--- a/src/show/Playlist.groovy
+++ b/src/show/Playlist.groovy
@@ -25,6 +25,10 @@ public class Playlist {
     this.channel = channel;
   }
 
+  public PlaylistItem getCurrentItem() {
+    this.items[this.currentIdx];
+  }
+
   // Plays a scene
   public void playItem(PlaylistItem item) {
     this.channel.setScene(item.scene, false, 10);
@@ -44,6 +48,12 @@ public class Playlist {
   private void scheduleNextScene(long delay) {
     TimerTask task = new TimerTask() {
       public void run() {
+        // always repeat for now
+        currentIdx++;
+        if (currentIdx >= items.size()) {
+          currentIdx = 0;
+        }
+
         play();
 
         //System.out.println("Task performed on: " + new Date() + "n" + "Thread's name: " + Thread.currentThread().getName());
@@ -67,12 +77,6 @@ public class Playlist {
       PlaylistItem nextItem = this.items[this.currentIdx];
       long delay = nextItem.duration * 1000 as long;
       this.scheduleNextScene(delay);
-    }
-
-    // always repeat for now
-    this.currentIdx++;
-    if (this.currentIdx >= this.items.size()) {
-      this.currentIdx = 0;
     }
   }
 

--- a/src/show/PlaylistItem.groovy
+++ b/src/show/PlaylistItem.groovy
@@ -3,7 +3,7 @@ package show
 // Playlist item: One scene + one duration.  and any other fields we decide we want
 public class PlaylistItem {
   // This needs its own ID so we know which item we're playing on the frontend and backend (and can agree)
-  // There can be more than one of the same scene per playlist, so we can't use the playlist id
+  // There can be more than one of the same scene per playlist, so we can't use the scene id
   // This doesn't need to be persistent, but it needs to be unique per instance of the backend
   String id;
   Scene scene;


### PR DESCRIPTION
changes:
- PlaylistItems now have unique ids.  It's not super important what they are, I just need them to be unique so we can agree on playlist item we're playing on the frontend and backend.  can't use sceneId because a playlist can contain more than one of the same scene
- Create global reference to Playlist object (need this so I can tell the frontend which Playlist we're playing when we load the initial state)
- Tweak when we increment the playlist.currentIdx variable.  This needs to be incremented right before we play a clip, not after we schedule the next clip.  Reason is that we need this to be correct whenever a client connects and requests initial state or it thinks we're playing the wrong scene
- The most important change is `handlePlaylistUpdate` - we can update the playlist data on the backend in response to a change on the frontend