### PR TITLE
Bmf sync control values to ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,7 @@ fabric.properties
 .gradle/
 build/
 
-##
+# More Intellij files
 .idea/compiler.xml
 .idea/dictionaries/aaronwilson.xml
 .idea/misc.xml
@@ -112,3 +112,6 @@ tesseract_java.iml
 #manually have to include this or have gradle download it separate from the repo
 
 lib/video/
+
+# temporary directory where we download dependencies before unpacking them
+tmp/

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id "de.undercouch.download" version "3.4.3"
+}
+
 // This allows us to compile either groovy or java from the same set of directories
 apply plugin: 'groovy'
 
@@ -33,7 +37,21 @@ dependencies {
   // https://mvnrepository.com/artifact/org.processing/video
   compile group: 'org.processing', name: 'video', version: '3.3.7'
 
+  // https://mvnrepository.com/artifact/org.freedesktop.gstreamer/gst1-java-core
+  compile group: 'org.freedesktop.gstreamer', name: 'gst1-java-core', version: '1.0.0'
+}
 
+task downloadProcessingVideoLibrary(type: Download) {
+  println "Downloading processing video library"
+  src 'https://github.com/processing/processing-video/releases/download/latest/video.zip'
+  dest new File("${rootDir}/tmp", 'processing-video-lib.zip')
+  onlyIfModified true
+}
+
+task unzipProcessingVideoLibrary(dependsOn: downloadProcessingVideoLibrary, type: Copy) {
+  println "Unzipping processing video library"
+  from zipTree(downloadProcessingVideoLibrary.dest)
+  into "${rootDir}/lib"
 }
 
 // To do this, I googled 'gradle build fat jar' and copied this from the first link (with a couple modifications)
@@ -46,3 +64,5 @@ task fatJar(type: Jar) {
   from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
   with jar
 }
+
+build.dependsOn unzipProcessingVideoLibrary

--- a/src/clip/ClipMetadata.groovy
+++ b/src/clip/ClipMetadata.groovy
@@ -55,6 +55,13 @@ class ClipMetadata {
                 [displayName: 'Blue', type: 'knob', defaultValue:  1.0, fieldName: 'p6'],
             ],
         ],
+        [
+            displayName: 'Video',
+            clipId     : 'video',
+            controls   : [
+                [displayName: 'Video File', type: 'videoFile', defaultValue:  '24K_loop-nosound.mp4', fieldName: 'filename'],
+            ],
+        ],
     ]
   }
 

--- a/src/model/Channel.java
+++ b/src/model/Channel.java
@@ -162,4 +162,9 @@ public class Channel {
         return  _currentScene;
     }
 
+    // I need a reference to the 'active' clip, meaning the one we are playing or will be playing once the transition is finished
+    // Returns _nextScene.clip if _nextScene is not null, otherwise _currentScene.clip
+    public AbstractClip getActiveClip() {
+        return this._nextScene != null ? this._nextScene.clip : this._currentScene.clip;
+    }
 }

--- a/src/show/PlaylistItem.groovy
+++ b/src/show/PlaylistItem.groovy
@@ -17,5 +17,4 @@ public class PlaylistItem {
     this.scene = scene;
     this.duration = duration;
   }
-
 }

--- a/src/show/PlaylistManager.groovy
+++ b/src/show/PlaylistManager.groovy
@@ -80,15 +80,9 @@ public class PlaylistManager {
   public play(Integer playlistId = null, String playlistItemId = null, PlayState playState) {
     Playlist p = this.getInitialPlaylist(playlistId)
 
-    println "[PlaylistManager] Playing playlist '${p.getDisplayName()}'. PlayState: ${p.getCurrentPlayState()}"
+    println "[PlaylistManager] Playing playlist '${p.getDisplayName()}'. PlayState: ${playState}"
 
     if (this.currentPlaylist != p) {
-      if (!this.currentPlaylist) {
-//        println "[PlaylistManager: Playing initial playlist ${p.getDisplayName()}"
-      } else {
-//        println "[PlaylistManager: Switching playlist from ${this.getCurrentPlaylist().getDisplayName()} to ${p.getDisplayName()}"
-      }
-
       // Unset the channel on the old playlist, and set it on the new playlist
       if (this.currentPlaylist) {
         this.currentPlaylist.unload()

--- a/src/state/StateManager.groovy
+++ b/src/state/StateManager.groovy
@@ -167,10 +167,8 @@ class StateManager {
       return
     }
 
-    // check the current values and react accordingly
-    // if playState changed, but activePlaylist didn't, we need to be able to update the playState without restarting the playlist
+    // Just stop
     if (playState == Playlist.PlayState.STOPPED) {
-      // here we should just stop the playlist, doesn't matter
       println "[StateManager] playState updated to STOPPED"
       PlaylistManager.get().stop(playlistId, playlistItemId)
       return


### PR DESCRIPTION
Changes
- minor cleanup of a couple comments/log statements
- Add clip metadata for 'Video' clip type so we can display it in the UI
- Download the processing video library dependency and extract it to 'lib' by running `./gradlew build`
- Sync the state of the clip's controls to the UI, so our knobs and sliders are in the correct position in the UI on the initial load and when we change Scenes