### PR TITLE
Allow configuring the stage type and number of controllers via env vars

### DIFF
--- a/src/app/TesseractMain.java
+++ b/src/app/TesseractMain.java
@@ -10,6 +10,7 @@ import model.*;
 import state.StateManager;
 import stores.PlaylistStore;
 import stores.SceneStore;
+import util.AppSettings;
 import util.Util;
 import show.*;
 import websocket.WebsocketInterface;
@@ -36,21 +37,10 @@ public class TesseractMain extends PApplet {
       "Node Scan", "Solid", "Color Wash", "Video"
   };
 
-
   private OnScreen onScreen;
-
   public UDPModel udpModel;
   public Stage stage;
-
   public Channel channel1;
-  public Channel channel2;
-
-  public WebsocketInterface ws;
-  public StateManager stateManager;
-  public SceneStore sceneStore;
-  public PlaylistStore playlistStore;
-
-  public Playlist currentPlaylist;
 
   //Click the arrow on the line below to run the program in .idea
   public static void main(String[] args) {
@@ -79,39 +69,40 @@ public class TesseractMain extends PApplet {
 
     _main = this;
 
-    // Persistence / state update stuff
-    ws = WebsocketInterface.get();
-    stateManager = StateManager.get();
-    sceneStore = SceneStore.get();
-    // Doesn't make sense to fully implement this until we know more about how playlists are gonna work
-    playlistStore = PlaylistStore.get();
-
-    clear();
-
-    udpModel = new UDPModel(this);
-
-    onScreen = new OnScreen(this);
-
-    stage = new Stage(this);
-
-    //pass in an XML stage definition, eventually we might load a saved project which is a playlist and environment together
-    stage.buildStage();
-
-    //create channels
-    channel1 = new Channel(1);
-    //channel2 = new Channel(2);
-
-    //make a dummy clip, one way to use direct control and load a clip directly into a channel, no scene necessary
-    //channel1.constructNewClip(SOLID);
+    // Configure Data and Stores
 
     // Make some dummy data in the stores
     Util.createBuiltInScenes();
     Util.createBuiltInPlaylists();
 
+    // Saves the default data
     SceneStore.get().saveDataToDisk();
     PlaylistStore.get().saveDataToDisk();
 
-    // Set the channel on the playlist manager
+    // Initialize websocket connection
+    WebsocketInterface.get();
+
+    clear();
+
+    // Start listening for UDP messages.  Handles sending/receiving all UDP data
+    udpModel = new UDPModel(this);
+
+    // Draw the on-screen visualization
+    onScreen = new OnScreen(this);
+
+    // The stage is the LED mapping
+    stage = new Stage(this);
+
+    // Get the configured stage value.  Controlled via environment variable
+    String stageType = AppSettings.get("STAGE_TYPE");
+
+    // eventually we might load a saved project which is a playlist and environment together
+    stage.buildStage(stageType);
+
+    // create channel
+    channel1 = new Channel(1);
+
+    // Tell the PlaylistManager which channel to play playlists in
     PlaylistManager.get().setChannel(this.channel1);
 
     // Play the playlist with id = 1, play the first item in the playlist, and start in the 'looping' state
@@ -119,17 +110,6 @@ public class TesseractMain extends PApplet {
 
     // The shutdown hook will let us clean up when the application is killed
     createShutdownHook();
-
-
-    /*
-    //TEMP, just playing around
-    final File directory = new File("./");
-    System.out.println(directory.getAbsolutePath());
-
-    final File videoDirectory = new File("./data/videos");
-    Util.listFilesForFolder(videoDirectory);
-    */
-
   }
 
   @Override
@@ -191,53 +171,53 @@ public class TesseractMain extends PApplet {
     // These are hydrated from the json now.  creating them here will update the existing data in the store, but this can be commented out and it will load entirely from disk
     // If we specify the id in the constructor and it matches an existing Scene, it will update the data.  omitting the ID from the constructor will use the max id + 1 for the new scene
     Scene sScan = new Scene(6, "Node Scanner", TesseractMain.NODESCAN, new float[]{0, 0, 0, 0, 0, 0, 0});
-    this.sceneStore.addOrUpdate(sScan);
+    SceneStore.get().addOrUpdate(sScan);
 
     Scene sVid = new Scene(5, "First Video", TesseractMain.VIDEO, new float[]{0, 0, 0, 0, 0, 0, 0}, "videos/Acid Shapes __ Free Vj Loop.mp4");
-    this.sceneStore.addOrUpdate(sVid);
+    SceneStore.get().addOrUpdate(sVid);
 
     Scene sWash = new Scene(4, "Color Wash", TesseractMain.COLORWASH, new float[]{0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f});
-    this.sceneStore.addOrUpdate(sWash);
+    SceneStore.get().addOrUpdate(sWash);
 
     Scene sYellow = new Scene(1, "Yellow", TesseractMain.SOLID, new float[]{0, 0, 0, 1, 1, 0, 0});
-    this.sceneStore.addOrUpdate(sYellow);
+    SceneStore.get().addOrUpdate(sYellow);
 
     Scene sPurple = new Scene(2, "Purple", TesseractMain.SOLID, new float[]{0, 0, 0, 1, 0, 1, 0});
-    this.sceneStore.addOrUpdate(sPurple);
+    SceneStore.get().addOrUpdate(sPurple);
 
     Scene sRed = new Scene(3, "Red", TesseractMain.SOLID, new float[]{0, 0, 0, 1, 0, 0, 0});
-    this.sceneStore.addOrUpdate(sRed);
+    SceneStore.get().addOrUpdate(sRed);
   }
 
   private void createBuiltInPlaylists() {
     List<PlaylistItem> playlist1Items = new LinkedList<>(Arrays.asList(
 
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 5), 6),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 6), 6),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 4), 4),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 1), 3),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 4), 4),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 2), 4),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 3), 3),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 4), 5),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 3), 5),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 2), 7)
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 5), 6),
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 6), 6),
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 4), 4),
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 1), 3),
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 4), 4),
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 2), 4),
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 3), 3),
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 4), 5),
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 3), 5),
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 2), 7)
     ));
 
     Playlist playlist1 = new Playlist(1, "Cubotron", 60, playlist1Items);
-    this.playlistStore.addOrUpdate(playlist1);
+    PlaylistStore.get().addOrUpdate(playlist1);
 
     List<PlaylistItem> playlist2Items = new LinkedList<>(Arrays.asList(
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 1), 3),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 2), 3),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 1), 3),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 3), 3),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 1), 3),
-        new PlaylistItem(UUID.randomUUID().toString(), this.sceneStore.find("id", 2), 3)
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 1), 3),
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 2), 3),
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 1), 3),
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 3), 3),
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 1), 3),
+        new PlaylistItem(UUID.randomUUID().toString(), SceneStore.get().find("id", 2), 3)
     ));
 
     Playlist playlist2 = new Playlist(2, "Color Cube", 60, playlist2Items);
-    this.playlistStore.addOrUpdate(playlist2);
+    PlaylistStore.get().addOrUpdate(playlist2);
   }
 
   private void createShutdownHook() {

--- a/src/environment/Stage.java
+++ b/src/environment/Stage.java
@@ -30,23 +30,24 @@ public class Stage {
         _myMain = TesseractMain.getMain();
     }
 
-
-    public void buildStage(){
-
-        //buildCubotron();
-
-        //buildTesseractStage();
-
-        buildDracoStage();
-
-        //set the boundaries of the stage
-        for (Node n: nodes) {
-            if(n.x>maxW) maxW = n.x;
-            if(n.y>maxH) maxH = n.y;
-            if(n.z>maxD) maxD = n.z;
-        }
-
+  public void buildStage(String stageType) {
+    if (stageType.equals("CUBOTRON")) {
+      buildCubotron();
+    } else if (stageType.equals("TESSERACT")) {
+      buildTesseractStage();
+    } else if (stageType.equals("DRACO")) {
+      buildDracoStage();
+    } else {
+      throw new RuntimeException("ERROR: Invalid stage of type: " + stageType);
     }
+
+    //set the boundaries of the stage
+    for (Node n : nodes) {
+      if (n.x > maxW) maxW = n.x;
+      if (n.y > maxH) maxH = n.y;
+      if (n.z > maxD) maxD = n.z;
+    }
+  }
 
     private void buildTesseractStage(){
         int counter = 0;

--- a/src/output/UDPModel.java
+++ b/src/output/UDPModel.java
@@ -9,6 +9,7 @@ import processing.core.PApplet;
 
 import hardware.*;
 import environment.Node;
+import util.AppSettings;
 
 
 public class UDPModel {
@@ -40,9 +41,8 @@ public class UDPModel {
     public UDPModel(PApplet pApplet) {
         p = pApplet;
 
-        rabbits = new Rabbit[0];
-        teensies = new Teensy[4];
-
+        initRabbits();
+        initTeensies();
 
         //red
         c[0] = 200;//255 is max
@@ -71,6 +71,19 @@ public class UDPModel {
         udp.listen( false );
     }
 
+    // Initialize the rabbit controllers.  Number of controllers is set in env var NUM_RABBITS.  default is 0
+    private void initRabbits() {
+        Integer numRabbits = Integer.parseInt(AppSettings.get("NUM_RABBITS"));
+        rabbits = new Rabbit[numRabbits];
+        // TODO: need to initialize from values in env vars
+    }
+
+    // Initialize the teensy (draco) controllers.  Number of controllers is set in env var NUM_TEENSIES.  default is 0
+    private void initTeensies() {
+        Integer numTeensies = Integer.parseInt(AppSettings.get("NUM_TEENSIES"));
+        teensies = new Teensy[numTeensies];
+        // TODO: need to objects initialize from values in env vars
+    }
 
     void createNodeMap(){
         for (int k=0; k<12; k++){//y
@@ -153,6 +166,7 @@ public class UDPModel {
     }
 
 
+    // Send tile to Tesseract
     public void sendTileFrame(Tile tile){
         //data for one tile, one frame
         byte[] data = new byte[(432+4)]; //144 nodes * 3 channels per node = 432
@@ -189,6 +203,7 @@ public class UDPModel {
     }//end sendTileFrame
 
 
+    // Send data to the Draco panels via Teensy
     public void sendTeensyNodesAsPanels(Teensy teensy) {
 
         int length = teensy.nodeArray.length;

--- a/src/state/StateManager.groovy
+++ b/src/state/StateManager.groovy
@@ -80,11 +80,13 @@ class StateManager {
       }
     }
 
+    // It doesn't matter if a bunch of these are null.  If the UI requests the data before we've played a playlist,
+    // there won't be a currentPlaylist.  When we start playing a playlist, we will update the activeState in the UI
     Map activeState = [
         playlistItemId               : playlistItemId,
-        playlistId                   : PlaylistManager.get().getCurrentPlaylist().getId(),
+        playlistId                   : PlaylistManager.get().getCurrentPlaylist()?.getId(),
         currentSceneDurationRemaining: PlaylistManager.get().getCurrentSceneDurationRemaining(),
-        playlistPlayState            : PlaylistManager.get().getCurrentPlaylist().getCurrentPlayState().name(),
+        playlistPlayState            : PlaylistManager.get().getCurrentPlaylist()?.getCurrentPlayState()?.name(),
         clipControlValues            : this.getClipControlValues(this.getActiveClip())
     ]
 

--- a/src/util/AppSettings.groovy
+++ b/src/util/AppSettings.groovy
@@ -1,0 +1,24 @@
+package util
+
+// This class will control fetching settings values for configuring the application
+// Right now they come from environment variables, but we could have them come from configuration files or other sources as well
+
+public class AppSettings {
+
+  // Default values for the settings
+  private static defaults = [
+      STAGE_TYPE: 'CUBOTRON',
+      NUM_TEENSIES: '0',
+      NUM_RABBITS: '0',
+  ]
+
+  public static String get(String key) {
+    String settingValue = System.getenv(key) ?: defaults[key]
+
+    if (settingValue == null) {
+      throw new RuntimeException("ERROR: Setting value not defined: '${key}'")
+    }
+
+    settingValue
+  }
+}


### PR DESCRIPTION
PR makes it so we can run the backend locally again for local dev.
Changes
- Adds an 'AppSettings' class we can use to read application settings from environment variables
- Add a few settings: 'STAGE_TYPE', 'NUM_TEENSIES', 'NUM_RABBITS' to control the number of controllers and which 'stage' to render
- Replace instance variables with singleton getters for stores (cleanup)
- Delete some unused vars
- Fix NPE if the backend is started while the UI is running.  Was caused by more aggressive reconnection logic I implemented in the UI, now often the UI is requesting the initial state before the backend has had a chance to load its initial data