### PR TITLE
Upgrade processing video library to the latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,30 +18,36 @@ sourceSets {
 }
 
 dependencies {
-  // Declare dependencies here
-  compile group: 'org.java-websocket', name: 'Java-WebSocket', version: '1.4.0'
+  // Groovy - used to compile Groovy projects.  This is what allows IntelliJ to provide groovy code completion & introspection
   compile group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.5.6'
 
+  // Common lib for logging
   // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
   compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.26'
 
+  // Common lib for logging
   // https://mvnrepository.com/artifact/org.slf4j/slf4j-simple
   compile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.26'
 
+  // Websocket library used to communicate with the UI
+  compile group: 'org.java-websocket', name: 'Java-WebSocket', version: '1.4.0'
+
+  // Core Processing Library
   // https://mvnrepository.com/artifact/org.processing/core
   compile group: 'org.processing', name: 'core', version: '3.3.6'
 
+  // OpenGL Java Bindings
+  // https://mvnrepository.com/artifact/org.jogamp.jogl/jogl-all-main
+  compile group: 'org.jogamp.jogl', name: 'jogl-all-main', version: '2.3.2'
+
   // Include all jar files in 'lib' automatically
   compile fileTree(dir: 'lib', include: ['**/*.jar'])
-
-  // https://mvnrepository.com/artifact/org.processing/video
-  compile group: 'org.processing', name: 'video', version: '3.3.7'
 }
 
 task downloadProcessingVideoLibrary(type: Download) {
   println "Downloading processing video library"
-  src 'https://github.com/processing/processing-video/releases/download/latest/video.zip'
-  dest new File("${rootDir}/tmp", 'processing-video-lib.zip')
+  src 'https://github.com/processing/processing-video/releases/download/r5-v2.0-beta3/video-2.0-beta3.zip'
+  dest new File("${rootDir}/tmp", 'processing-video-lib-v2-beta-release-5.zip')
   onlyIfModified true
 }
 

--- a/src/clip/VideoClip.groovy
+++ b/src/clip/VideoClip.groovy
@@ -24,6 +24,8 @@ public class VideoClip extends AbstractClip{
     private int _videoW = 640;
     private int _videoH = 360;
 
+    // We have to define the field here too or Groovy tries to call setFilename when we do 'this.filename = filename' below, leading to an infinite loop.  Annoying
+    public filename;
 
     //constructor
     public VideoClip() {
@@ -91,9 +93,18 @@ public class VideoClip extends AbstractClip{
         int c = 0;
         if(movie != null) {
             //make sure we don't overrun the array which can happen when pixels go offscreen
+            // This is to handle a case when we are switching the video file and don't want to get exceptions
             if (loc >= 0 && loc < movie.pixels.length) {
-                // This is to handle a case when we are switching the video file and don't want to get exceptions
-                c = movie.pixels[loc];
+                // Unfortunately, with the upgraded video library, the 'pixels' array on the 'movie' object is never filled with data (all 0s)
+                //
+                // The movie object has no 'bufferSync' property, so it never fills the 'pixel' array with the pixes
+                // stored in 'copyPixels' (I stepped thru the code w/ a debugger).  It doesn't have a 'bufferSync' because
+                // an internal call to 'this.parent.g.getCache(this);' returns null
+                // I have no clue why any of this should be the case, or why the behavior differs from the v1 release of the library,
+                // but using copyPixels works for our purposes.  The file needs to be a .groovy file, so we can access the 'protected' field 'copyPixels'.
+                //
+                // Even more confused as to why the sign of the int is wrong, but negating the value seems to make the colors look correct
+                c = -movie.copyPixels[loc];
             }
         }
 


### PR DESCRIPTION
Upgrades the processing video library to the latest version.  This should make it easier to use on Linux
There were a couple of hiccups but its all working.

It turns out that we were loading multiple versions of the library, due to including `compile group: 'org.processing', name: 'video', version: '3.3.7'` in the build.gradle file as well as including the `.jar` files from the manually extracted `lib/video` directory.  This made understanding what was happening on Linux difficult and made debugging unreliable.  With this change we will only be loading one version of the libraries.  The new version of the processing video library uses a much newer version of the `gstreamer` library (v1.6 vs 0.10) which should be a good thing.

One minor issue is that with the newer library, the `movie.pixels` array is never filled with values.  However, there is another array called `movie.copyPixels` that does contain the correct data.  Unfortunately, have to convert `VideoClip.java` to a `.groovy` file to access the field because it is `protected` (groovy lets you do dumb things, if you really want)

I'm not super stoked on this change, I would prefer to figure out why `movie.pixels` isn't being populated and fix the root issue, but I spent ~ an hour on it and couldn't get to the root cause.  However I'm going to carry on with it because I think it might help get video playback working on Linux.

I'm putting this PR up so you can look at it and give me feedback.  Please run it and tell me if you notice anything wonky, everything looked good to me.