### PR TITLE
Add build_macos.sh script.  Automatically run it from start_macos.sh …

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,22 @@ Now every time you open the project, you can run it easily by pressing the 'play
 
 A fat jar file is a jar (compiled java application) that contains all necessary dependencies to be run independently.
 
-To build a far jar, run the command `./gradlew fatJar` in the repo directory.
+To build a far jar, run the command `./gradlew unzipProcessingVideoLibrary unzipProcessingUdpLibrary untarProcessingCoreLibrary downloadJoglJar fatJar` in the repo directory.
+
+The unzip/untar commands add a bit to the application startup time when running in IntelliJ, so they don't automatically run by default and must be run manually.
 
 The jar will be created in the `./build/libs` directory.
 
 To run the resulting jar: `java -jar ./build/libs TesseractFatJar`.
+
+### macos
+
+There are helper scripts in the `bin` directory to enable you to easily build and run the application.  
+
+Use `./bin/build_macos.sh` to build the jar and `./bin/start_macos.sh` to run the application.
+
+Running `./bin/start_macos.sh` will automatically build the jar if it doesn't exist.
+
+### linux
+
+The process is largely the same for Linux.  The same scripts may even work, but they are untested on Linux.

--- a/bin/build_macos.sh
+++ b/bin/build_macos.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -el
+
+script_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+repo_path="$script_path/.."
+
+cd $repo_path
+
+echo "Building fat jar"
+
+./gradlew unzipProcessingVideoLibrary unzipProcessingUdpLibrary untarProcessingCoreLibrary downloadJoglJar fatJar
+
+echo "Successfully built fat jar"

--- a/bin/start_macos.sh
+++ b/bin/start_macos.sh
@@ -7,7 +7,10 @@ jar_path="$repo_path/build/libs/TesseractFatJar.jar"
 
 echo "Checking for jar at path: ${jar_path}"
 
-[[ ! -f $jar_path ]] && { echo "ERROR: You must build the jar first.  Run ./gradlew fatJar"; exit 1; }
+[[ ! -f $jar_path ]] && {
+  echo "Did not find jar at path ${jar_path}.  Running ./build_macos.sh"
+  ${repo_path}/bin/build_macos.sh
+}
 
 cd $repo_path
 

--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,3 @@ task fatJar(type: Jar) {
   from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
   with jar
 }
-
-// Force downloading the dependencies before we compile the code
-//compileGroovy.dependsOn unzipProcessingVideoLibrary, unzipProcessingUdpLibrary, untarProcessingCoreLibrary, downloadJoglJar


### PR DESCRIPTION
…if the jar doesn't exist

Changes
- Don't automatically resolve the dependencies when compiling the code.  This was adding undesirable time to the startup of the app from within IntelliJ
- Add `build_macos.sh` script to assist with building the jar
- Call `build_macos.sh` from `start_macos.sh` if the jar hasn't been built yet