### PR TITLE
Initial cut of loading configuration values from a file.  We load the…

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,29 @@ Running `./bin/start_macos.sh` will automatically build the jar if it doesn't ex
 ### linux
 
 The process is largely the same for Linux.  The same scripts may even work, but they are untested on Linux.
+
+## Configuration
+
+Tesseract Java is configured via a YAML configuration file named 'tesseract-config.yml'.
+
+By default, it will look in the location `./config/tesseract-config.yml`.  If it doesn't exist, the app will print a warning and use default values.
+
+You can pass in a path to your configuration file via the system property `configPath` (e.g., `java -DconfigPath=/path/to/config/tesseract-config.yml`).
+
+The repo contains a configuration file in `<repo>/config/tesseract-config.yml` that you can use as an example.  This is the file that will be used when running the application via your IDE.
+
+### Configuration options
+
+#### initialPlaylist
+
+This option controls which playlist will load by default when the application starts.  Specify the 'displayName' property of the playlist.  If the playlist doesn't exist, the application will throw an error and exit.  These values are case-sensitive.
+
+#### initialPlayState
+
+This option controls the initial 'playState' of the application.  Applicable values are `loop_scene`, `playing`, or `stopped`.  These values are case-insensitive and will be converted to all caps internally.
+
+`loop_scene` will simply continue playing the first scene continuously forever.
+
+`playing` will advance scenes in the playlist according to the specified duration.
+
+`stopped` will not play anything (the LEDs will be dark)

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
   // Websocket library used to communicate with the UI
   compile group: 'org.java-websocket', name: 'Java-WebSocket', version: '1.4.0'
 
+  // YAML parser used for reading config files
+  // https://mvnrepository.com/artifact/org.yaml/snakeyaml
+  compile group: 'org.yaml', name: 'snakeyaml', version: '1.24'
+
   // Include all jar files in 'lib' automatically
   compile fileTree(dir: 'lib', include: ['**/*.jar'])
 }

--- a/config/tesseract-config.yml
+++ b/config/tesseract-config.yml
@@ -1,0 +1,2 @@
+initialPlaylist: Color Cube
+initialPlayState: loop_scene

--- a/src/app/TesseractMain.java
+++ b/src/app/TesseractMain.java
@@ -8,6 +8,7 @@ import processing.core.PApplet;
 import processing.video.Movie;
 import show.Playlist;
 import show.PlaylistManager;
+import stores.ConfigStore;
 import stores.PlaylistStore;
 import stores.SceneStore;
 import util.AppSettings;
@@ -70,9 +71,13 @@ public class TesseractMain extends PApplet {
     SceneStore.get().saveDataToDisk();
     PlaylistStore.get().saveDataToDisk();
 
+    // Load configuration from file.  This must happen AFTER we've created our initial playlists, or it will fail on a fresh install
+    ConfigStore.get();
+
     // Initialize websocket connection
     WebsocketInterface.get();
 
+    // Clear screen
     clear();
 
     // Start listening for UDP messages.  Handles sending/receiving all UDP data
@@ -96,12 +101,15 @@ public class TesseractMain extends PApplet {
     // Tell the PlaylistManager which channel to play playlists in
     PlaylistManager.get().setChannel(this.channel1);
 
-    // Play the playlist with id = 1, play the first item in the playlist, and start in the 'looping' state
-    PlaylistManager.get().play(2, null, Playlist.PlayState.LOOP_SCENE);
+    // Get initial playlist & playState from config
+    Playlist initialPlaylist = PlaylistStore.get().find("displayName", ConfigStore.get().getString("initialPlaylist"));
+    Playlist.PlayState initialPlayState = Util.getPlayState(ConfigStore.get().getString("initialPlayState"));
 
-    // The shutdown hook will let us clean up when the application is killed
+    // Play the playlist w/ the playState defined in our configuration
+    PlaylistManager.get().play(initialPlaylist.getId(), null, initialPlayState);
+
+    // The shutdown hook will let us clean up when the application is killed.  It is very important to clean up the websocket server so we don't leave the port in use
     createShutdownHook();
-
   }
 
   @Override

--- a/src/show/Playlist.groovy
+++ b/src/show/Playlist.groovy
@@ -196,7 +196,7 @@ public class Playlist {
     this.channel.setScene(item.scene, false, 10);
 
     //wrap this in a "debug"
-    System.out.println("[Playlist] Playing scene '${item.scene.getDisplayName()}' on playlist '${this.displayName}'");
+    System.out.println("[Playlist] Playing scene '${item.scene.getDisplayName()}' on playlist '${this.displayName}' (Playstate: ${playState})");
 
     // Schedule the next item
     if (playState == PlayState.PLAYING) {

--- a/src/state/StateManager.groovy
+++ b/src/state/StateManager.groovy
@@ -227,7 +227,7 @@ class StateManager {
     String playlistItemId = inData.activePlaylistItemId
     Playlist.PlayState playState = inData.playState as Playlist.PlayState
 
-    // if we're already playing the correct playlist and item and we're in the correct playstate, don't do anything
+    // if we're already playing the correct playlist and item and we're in the correct playState, don't do anything
     // this should prevent the playlist from restarting if we click it again in the UI and we're already on it
     if (playlistId == PlaylistManager.get().getCurrentPlaylist().getId()
             && playlistItemId == PlaylistManager.get().getCurrentPlaylist().getCurrentItem()?.getId()
@@ -243,7 +243,7 @@ class StateManager {
       return
     }
 
-    // If we made it this far, we should play the incoming playlist, item, and playstate
+    // If we made it this far, we should play the incoming playlist, item, and playState
     PlaylistManager.get().play(playlistId, playlistItemId, playState)
   }
 }

--- a/src/stores/ConfigStore.groovy
+++ b/src/stores/ConfigStore.groovy
@@ -1,0 +1,107 @@
+package stores
+
+import show.Playlist
+import util.Util
+import org.yaml.snakeyaml.Yaml
+
+class ConfigStore extends BaseStore {
+  public static ConfigStore instance
+
+  // this is the data read from the configuration file
+  private Map configData
+
+  // Map of data/functions for the config options
+  // defaultValue - the value that will be used if the field isn't defined in the config file, or there is no config file loaded
+  // transformValue - a function that will transform the value when it is loaded.  for example, we require the playState to be ALL_CAPS, this allows us to transform it when we load the data
+  // validateFn - a function to validate the config option.  returns true if its valid, otherwise false
+  // validateFailMsgFn - a function that returns the error message to print when validation fails.  The function is passed the value that caused the validation to fail.  This is REQUIRED if validateFn is defined
+  // EVERY option must have an entry in this map, or we won't load it!
+  private Map configOptions = [
+      initialPlaylist : [
+          defaultValue     : 'Color Cube',
+          validateFn       : { PlaylistStore.get().find('displayName', it) != null },
+          validateFailMsgFn: { "Playlist '${it}' does not exist" }
+      ],
+      initialPlayState: [
+          defaultValue     : 'loop_scene',
+          transformValueFn : { it.toUpperCase() },
+          validateFn       : { String playStateStr ->
+            try {
+              playStateStr as Playlist.PlayState
+            } catch (IllegalArgumentException e) {
+              return false
+            }
+          },
+          validateFailMsgFn: { "PlayState '${it}' is invalid.  Must be one of 'playing', 'loop_scene', or 'stopped'" },
+      ],
+  ]
+
+  // Singleton
+  public static ConfigStore get() {
+    if (instance == null) {
+      instance = new ConfigStore()
+    }
+
+    instance
+  }
+
+  public ConfigStore() {
+    this.loadConfigData()
+  }
+
+  // Loads the configuration data, transforms the values, validates the values, then populates the maps we use to retrieve the values
+  private loadConfigData() {
+    // read in configuration file.  defaults to config/tesseract-config.yml
+    String configPath = System.getProperty("configPath") ?: 'config/tesseract-config.yml'
+
+    File configFile = new File(configPath)
+
+    // The config options we've loaded from the file
+    Map loadedConfigData = [:]
+
+    // Final storage place for the config options
+    this.configData = [:]
+
+    if (configFile.exists()) {
+      println "Reading config file from ${configFile.getCanonicalPath().cyan()}".yellow()
+      loadedConfigData = new Yaml().load(configFile.text)
+    } else {
+      println("WARNING: No configuration file found at '${configFile.getCanonicalPath()}'.  Using default values")
+    }
+
+    this.configOptions.each { optionKey, optionData ->
+      def value = loadedConfigData[optionKey] ?: optionData.defaultValue
+
+      // Transform values if the transformValueFn function is defined
+      if (optionData.transformValueFn != null) {
+        value = optionData.transformValueFn(value)
+      }
+
+      // Validate the options with the validateFn function, print errors with the validateFailMsgFn
+      if (optionData.validateFn != null && !optionData.validateFn(value)) {
+        Util.throwException("ERROR: Failed validation of option '${optionKey}': ${optionData.validateFailMsgFn(value)}")
+      }
+
+      this.configData[optionKey] = value
+    }
+  }
+
+  // Get a Boolean config value
+  public Boolean getBool(String key) {
+    this.getOption(Boolean, key)
+  }
+
+  // Get a String config value
+  public String getString(String key) {
+    this.getOption(String, key)
+  }
+
+  // Internal method that does some type checking
+  private getOption(Class type, String key) {
+    def value = this.configData[key] ?: this.defaultConfigValues[key]
+    if (!(type.isInstance(value))) {
+      Util.throwException("ERROR: config option with key '${key}' is not type '${type.toString()}'")
+    }
+    value
+  }
+}

--- a/src/util/Util.groovy
+++ b/src/util/Util.groovy
@@ -3,6 +3,7 @@ package util
 import app.TesseractMain
 import groovy.json.JsonBuilder
 import show.Playlist
+import show.Playlist.PlayState
 import show.PlaylistItem
 import show.Scene
 import stores.MediaStore
@@ -222,5 +223,10 @@ public class Util {
 
   public static void throwException(String msg) {
     throw new RuntimeException(msg)
+  }
+
+  // Transform a string playState to the enum.  Way easier to do it here than in Java
+  public static PlayState getPlayState(String playStateStr) {
+    playStateStr as PlayState
   }
 }


### PR DESCRIPTION
… initialPlaylist and initialPlayState from the config file

Initial changes to load some configuration from a config file

Changes:
- Config files are in `yml` format
- Available options as of this commit: `initialPlaylist` and `initialPlayState`
- standardize capitalization of `playState` across all files
- added info to README.md about the config file
- Create `ConfigStore` class which handles loading and fetching the configuration values.  Eventually this will handle loading from file vs environment variables, etc
  - This class handles loading the data, transforming it into another value if necessary, validating the values, and printing useful error messages if an invalid value is set in the config file