### PR TITLE
Bmf add tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ dependencies {
 
   // Some random io utilities
   // https://mvnrepository.com/artifact/commons-io/commons-io
-  compile group: 'commons-io', name: 'commons-io', version: '2.6'
+  testCompile group: 'commons-io', name: 'commons-io', version: '2.6'
 }
 
 task downloadProcessingVideoLibrary() {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 // This allows us to compile either groovy or java from the same set of directories
+apply plugin: 'java'
 apply plugin: 'groovy'
 
 repositories {
@@ -42,6 +43,41 @@ dependencies {
 
   // Include all jar files in 'lib' automatically
   compile fileTree(dir: 'lib', include: ['**/*.jar'])
+
+  //////////////// For unit/integration tests
+
+  // https://mvnrepository.com/artifact/junit/junit
+  testCompile group: 'junit', name: 'junit', version: '4.12'
+
+  // Mocking library
+  // https://mvnrepository.com/artifact/org.mockito/mockito-core
+  testCompile group: 'org.mockito', name: 'mockito-core', version: '2.28.2'
+
+  // Lets us mock even harder.  To the max
+  // https://mvnrepository.com/artifact/org.powermock/powermock-core
+  testCompile group: 'org.powermock', name: 'powermock-core', version: '2.0.2'
+
+  // https://mvnrepository.com/artifact/org.powermock/powermock-module-junit4
+  testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.2'
+
+  // https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2
+  testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.2'
+
+  // Hamcrest junit matchers
+  // https://mvnrepository.com/artifact/org.hamcrest/java-hamcrest
+  testCompile group: 'org.hamcrest', name: 'java-hamcrest', version: '2.0.0.0'
+
+  // Hamcrest junit matchers
+  // https://mvnrepository.com/artifact/org.hamcrest/hamcrest-junit
+  testCompile group: 'org.hamcrest', name: 'hamcrest-junit', version: '2.0.0.0'
+
+  // Allows capturing logs and exit status from commands
+  // https://mvnrepository.com/artifact/com.github.stefanbirkner/system-rules
+  testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
+
+  // Some random io utilities
+  // https://mvnrepository.com/artifact/commons-io/commons-io
+  compile group: 'commons-io', name: 'commons-io', version: '2.6'
 }
 
 task downloadProcessingVideoLibrary() {
@@ -134,4 +170,9 @@ task fatJar(type: Jar) {
   baseName = 'TesseractFatJar'
   from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
   with jar
+}
+
+test {
+  dependsOn cleanTest
+  testLogging.showStandardStreams = true
 }

--- a/src/main/stores/PlaylistStore.groovy
+++ b/src/main/stores/PlaylistStore.groovy
@@ -10,14 +10,11 @@ import util.Util
 
 class PlaylistStore extends BaseStore implements IJsonPersistable {
   public static PlaylistStore instance
-  public SceneStore sceneStore
 
   // List of PlaylistItems
   private List<Playlist> items = []
 
   public PlaylistStore() {
-    this.sceneStore = SceneStore.get()
-
     List<Map> data = this.loadDataFromDisk()
     refreshFromJS(data)
 
@@ -65,7 +62,7 @@ class PlaylistStore extends BaseStore implements IJsonPersistable {
   public Playlist createPlaylistFromJson(jsonObj) {
     List<PlaylistItem> playlistItems = jsonObj.items.collect { Map playlistItem ->
       // Find scene in scene store
-      Scene scene = this.sceneStore.find 'id', playlistItem.sceneId
+      Scene scene = SceneStore.get().find 'id', playlistItem.sceneId
 
       // create new id for playlist item if one doesn't exist
       String playlistItemId = playlistItem.id ?: UUID.randomUUID();

--- a/src/main/util/Util.groovy
+++ b/src/main/util/Util.groovy
@@ -49,7 +49,7 @@ public class Util {
   // Returns the directory we are going to use to store json files
   // 'group' will be a way we can have different sets of files
   // creates any necessary directories to ensure the path exists
-  public static getDataDir(String group = 'default') {
+  public static String getDataDir(String group = 'default') {
     // this returns '<repo dir>/data/<group>'
     String dirPath = "${new File(".").getAbsoluteFile().getParent()}/data/${group}"
     File dir = new File(dirPath)
@@ -57,7 +57,7 @@ public class Util {
       dir.mkdirs()
     }
 
-    dir
+    dir.getCanonicalPath()
   }
 
   // Get the data file path for a type

--- a/src/test/stores/ConfigStoreTest.groovy
+++ b/src/test/stores/ConfigStoreTest.groovy
@@ -1,0 +1,57 @@
+package stores
+
+import app.TesseractMain
+import org.apache.commons.io.FileUtils
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
+import testUtil.TestUtil
+import util.Util
+
+import java.nio.charset.Charset
+
+import static org.hamcrest.CoreMatchers.equalTo
+import static org.hamcrest.junit.MatcherAssert.assertThat
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest([TesseractMain.class, Util.class])
+class ConfigStoreTest {
+
+  public TesseractMain mockMain
+
+  public String testConfigFile = """
+    initialPlaylist: Something
+    initialPlayState: loop_scene
+  """.stripIndent()
+
+  @Rule
+  public TemporaryFolder tmpDir = new TemporaryFolder();
+
+  @Before
+  void setUp() {
+    Util.enableColorization()
+
+    TestUtil.mockUtilClass(tmpDir)
+
+    TestUtil.createMockPlaylist()
+
+    TestUtil.mockTesseractMain()
+  }
+
+  @Test
+  void testConfigStoreReadsFileAtConfigPath() {
+    File configFile = tmpDir.newFile()
+    FileUtils.writeStringToFile(configFile, this.testConfigFile, Charset.defaultCharset())
+
+    // Set the config path for the application
+    System.setProperty('configPath', configFile.getCanonicalPath())
+
+    ConfigStore store = ConfigStore.get()
+
+    assertThat store.getString('initialPlaylist'), equalTo('Something')
+  }
+}

--- a/src/test/testUtil/MockMain.groovy
+++ b/src/test/testUtil/MockMain.groovy
@@ -1,0 +1,11 @@
+package testUtil
+
+import app.TesseractMain
+
+// This is a class where we can mock any functions that are called in TesseractMain
+// Typically these are actually inherited functions from Processing's PApplet class
+class MockMain extends TesseractMain {
+  public int color() {
+    return 0
+  }
+}

--- a/src/test/testUtil/TestUtil.groovy
+++ b/src/test/testUtil/TestUtil.groovy
@@ -1,0 +1,39 @@
+package testUtil
+
+import app.TesseractMain
+import groovy.json.JsonBuilder
+import org.junit.rules.TemporaryFolder
+import org.powermock.api.mockito.PowerMockito
+import util.Util
+
+import static org.mockito.Mockito.when
+
+class TestUtil {
+  public static void mockTesseractMain() {
+    PowerMockito.mockStatic(TesseractMain.class)
+    when(TesseractMain.getMain()).thenReturn(TestUtil.getMockMain())
+  }
+
+  public static TesseractMain getMockMain() { new MockMain() }
+
+  // Mock some of the functions in the util class
+  public static void mockUtilClass(TemporaryFolder tmpDir) {
+    // By using 'stub', we can mock specific methods without messing with the rest of them
+    String dataDir = tmpDir.getRoot().getCanonicalPath()
+    PowerMockito.stub(PowerMockito.method(Util.class, "getDataDir")).toReturn(dataDir);
+  }
+
+  public static void createMockPlaylist() {
+    def jsonObj = [
+        [
+            id         : 1,
+            displayName: 'Something',
+            items      : []
+        ]
+    ]
+
+    String playlistJsonPath = Util.getDataFilePath('playlist')
+
+    new File(playlistJsonPath).write "${new JsonBuilder(jsonObj).toPrettyString()}\n"
+  }
+}


### PR DESCRIPTION
Gets tests working.  The code is here to mock out the necessary stuff so we can actually test our classes in relative isolation (without Processing running).

Adds one test that verifies ConfigStore will properly read in a configuration file and set the `initialPlaylist` value.