### PR TITLE
Bmf test configstore

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,5 +174,9 @@ task fatJar(type: Jar) {
 
 test {
   dependsOn cleanTest
-  testLogging.showStandardStreams = true
+  testLogging {
+    showStandardStreams = true
+    events "passed", "skipped", "failed"
+    exceptionFormat = 'full'
+  }
 }

--- a/src/main/stores/ConfigStore.groovy
+++ b/src/main/stores/ConfigStore.groovy
@@ -77,11 +77,6 @@ class ConfigStore extends BaseStore {
         value = optionData.transformValueFn(value)
       }
 
-      // Validate the options with the validateFn function, print errors with the validateFailMsgFn
-      if (optionData.validateFn != null && !optionData.validateFn(value)) {
-        Util.throwException("ERROR: Failed validation of option '${optionKey}': ${optionData.validateFailMsgFn(value)}")
-      }
-
       this.configData[optionKey] = value
     }
   }
@@ -102,6 +97,12 @@ class ConfigStore extends BaseStore {
     if (!(type.isInstance(value))) {
       Util.throwException("ERROR: config option with key '${key}' is not type '${type.toString()}'")
     }
+
+    // Validate the options with the validateFn function, print errors with the validateFailMsgFn
+    if (this.configOptions[key].validateFn != null && !this.configOptions[key].validateFn(value)) {
+      Util.throwException("ERROR: Failed validation of option '${key}': ${this.configOptions[key].validateFailMsgFn(value)}")
+    }
+
     value
   }
 }

--- a/src/main/stores/SceneStore.groovy
+++ b/src/main/stores/SceneStore.groovy
@@ -8,7 +8,7 @@ import state.IJsonPersistable
 import util.Util
 
 class SceneStore extends BaseStore implements IJsonPersistable {
-  private static SceneStore instance
+  public static SceneStore instance
   private List<Scene> items = []
 
   public SceneStore() {

--- a/src/main/util/Util.groovy
+++ b/src/main/util/Util.groovy
@@ -22,6 +22,9 @@ public class Util {
     String.metaClass.blue = { -> delegate.colorize(34) }
     String.metaClass.magenta = { -> delegate.colorize(35) }
     String.metaClass.cyan = { -> delegate.colorize(36) }
+
+    // Method to strip colors from output
+    String.metaClass.stripColors = { -> delegate.replaceAll("\u001B\\[[;\\d]*m", "") }
   }
 
   // Ensure data dir exists

--- a/src/test/integration/README.md
+++ b/src/test/integration/README.md
@@ -1,0 +1,4 @@
+# integration tests
+
+These tests run the entire application and perform assertions against the output.  We can use this to verify the application
+runs without errors after we make changes.

--- a/src/test/integration/TesseractAppTest.groovy
+++ b/src/test/integration/TesseractAppTest.groovy
@@ -1,10 +1,15 @@
 package integration
 
 import app.TesseractMain
+import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.contrib.java.lang.system.SystemErrRule
 import org.junit.contrib.java.lang.system.SystemOutRule
+import stores.ConfigStore
+import stores.MediaStore
+import stores.PlaylistStore
+import stores.SceneStore
 
 import java.util.regex.Pattern
 
@@ -20,6 +25,16 @@ class TesseractAppTest {
   @Rule
   public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
 
+  @After
+  void teardown() {
+    // Reset all singleton instances so we have fresh ones for each test
+    // We will need to do this in every test suite.  Maybe do something like this: https://igorski.co/java/junit/run-stuff-before-and-after-each-test-in-junit4/
+    ConfigStore.instance = null
+    MediaStore.instance = null
+    PlaylistStore.instance = null
+    SceneStore.instance = null
+  }
+
   @Test
   public void testCanStartApplication() {
     // Launch the application by calling the 'main' method
@@ -32,7 +47,6 @@ class TesseractAppTest {
     String stderr = systemErrRule.getLog().stripColors()
 
     List<String> expectedStrings = [
-        'Loading scene data from Disk',
         'Wrote Scene Data to Disk',
         'Writing Playlist Data to Disk',
         'Wrote Playlist Data to Disk',

--- a/src/test/integration/TesseractAppTest.groovy
+++ b/src/test/integration/TesseractAppTest.groovy
@@ -1,0 +1,58 @@
+package integration
+
+import app.TesseractMain
+import org.junit.Rule
+import org.junit.Test
+import org.junit.contrib.java.lang.system.SystemErrRule
+import org.junit.contrib.java.lang.system.SystemOutRule
+
+import java.util.regex.Pattern
+
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.Matchers.matchesPattern
+import static org.hamcrest.junit.MatcherAssert.assertThat
+
+class TesseractAppTest {
+
+  @Rule
+  public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+
+  @Rule
+  public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
+
+  @Test
+  public void testCanStartApplication() {
+    // Launch the application by calling the 'main' method
+    TesseractMain.main([] as String[])
+
+    // Give the application a few seconds to launch
+    sleep 5 * 1000
+
+    String stdout = systemOutRule.getLog().stripColors()
+    String stderr = systemErrRule.getLog().stripColors()
+
+    List<String> expectedStrings = [
+        'Loading scene data from Disk',
+        'Wrote Scene Data to Disk',
+        'Writing Playlist Data to Disk',
+        'Wrote Playlist Data to Disk',
+        'Reading config file from /Users/fry/code/tesseract_java/config/tesseract-config.yml',
+        'WebsocketInterface started on port: 8883',
+        'Websocket server started',
+        "[Playlist] Playing scene 'PerlinNoise' on playlist 'Color Cube' (Playstate: LOOP_SCENE)",
+        '[StateManager] Sending stateUpdate event: activeState',
+    ]
+
+    // Assert that all of the expected strings appear in the output
+    expectedStrings.each { String expected ->
+      assertThat stdout, matchesPattern(~/[\s\S]*${Pattern.quote(expected)}[\s\S]*/)
+    }
+
+    // Assert that nothings been printed to stderr
+    assertThat stderr.size(), equalTo(0)
+
+    // The application will die immediately when this application finishes.  Use a 'sleep' if we want it to stay up longer
+    // for any particular reason
+    // sleep 1000 * 1
+  }
+}

--- a/src/test/testUtil/TestUtil.groovy
+++ b/src/test/testUtil/TestUtil.groovy
@@ -23,8 +23,9 @@ class TestUtil {
   // Mock some of the functions in the util class
   public static void mockUtilClass(TemporaryFolder tmpDir) {
     // By using 'stub', we can mock specific methods without messing with the rest of them
+    // We MUST specify the parameter types or it will silently ignore our mock!
     String dataDir = tmpDir.getRoot().getCanonicalPath()
-    PowerMockito.stub(PowerMockito.method(Util.class, "getDataDir")).toReturn(dataDir);
+    PowerMockito.stub(PowerMockito.method(Util.class, "getDataDir", String)).toReturn(dataDir);
   }
 
   public static Map getMockPlaylist(Map data) {

--- a/src/test/testUtil/TestUtil.groovy
+++ b/src/test/testUtil/TestUtil.groovy
@@ -2,9 +2,13 @@ package testUtil
 
 import app.TesseractMain
 import groovy.json.JsonBuilder
+import org.apache.commons.io.FileUtils
 import org.junit.rules.TemporaryFolder
 import org.powermock.api.mockito.PowerMockito
+import org.yaml.snakeyaml.Yaml
 import util.Util
+
+import java.nio.charset.Charset
 
 import static org.mockito.Mockito.when
 
@@ -23,17 +27,31 @@ class TestUtil {
     PowerMockito.stub(PowerMockito.method(Util.class, "getDataDir")).toReturn(dataDir);
   }
 
-  public static void createMockPlaylist() {
-    def jsonObj = [
-        [
-            id         : 1,
-            displayName: 'Something',
-            items      : []
-        ]
-    ]
+  public static Map getMockPlaylist(Map data) {
+    [
+        id         : 1,
+        displayName: 'Something',
+        items      : []
+    ] + data
+  }
+
+  public static void createMockPlaylists(Map playlistData) {
+    TestUtil.createMockPlaylists([playlistData])
+  }
+
+  public static void createMockPlaylists(List<Map> playlistData = [[:]]) {
+    List<Map> playlists = playlistData.collect { getMockPlaylist(it) }
 
     String playlistJsonPath = Util.getDataFilePath('playlist')
 
-    new File(playlistJsonPath).write "${new JsonBuilder(jsonObj).toPrettyString()}\n"
+    new File(playlistJsonPath).write "${new JsonBuilder(playlists).toPrettyString()}\n"
+  }
+
+  public static void mockConfigFile(tmpDir, Map configData) {
+    File configFile = tmpDir.newFile()
+    FileUtils.writeStringToFile(configFile, new Yaml().dump(configData), Charset.defaultCharset())
+
+    // Set the config path for the application
+    System.setProperty('configPath', configFile.getCanonicalPath())
   }
 }


### PR DESCRIPTION
I got a few more tests written.  I believe the current functionality in the ConfigStore is pretty well tested.

I also added a test that launches the entire processing app and makes assertions against the output (stdout).  We can tweak that test as needed to catch errors and ensure the entire application at minimum launches and is usable.

run tests with `./gradlew test` or by clicking the green arrows in IntelliJ (in the gutter next to the line numbers, same as you would click to launch the main app)